### PR TITLE
feat: scaffold workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,10 @@
+[workspace]
+members = [
+    "cnfg",
+    "cnfg-core",
+    "cnfg-derive",
+    "cnfg-sources",
+    "cnfg-validate",
+    "cnfg-examples",
+]
+resolver = "2"

--- a/cnfg-core/Cargo.toml
+++ b/cnfg-core/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cnfg-core"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+thiserror = "1"

--- a/cnfg-core/src/lib.rs
+++ b/cnfg-core/src/lib.rs
@@ -1,0 +1,106 @@
+#![deny(missing_docs, warnings)]
+
+//! Core traits and error types for the `cnfg` configuration framework.
+//!
+//! This crate defines the `Config` trait alongside supporting enums and
+//! errors used throughout the configuration ecosystem. Library authors can
+//! depend on `cnfg-core` without pulling in any optional configuration
+//! sources or validation helpers.
+//!
+//! # Example
+//!
+//! ```
+//! use cnfg_core::{Config, ConfigError};
+//!
+//! #[derive(Debug)]
+//! struct SampleConfig {
+//!     debug: bool,
+//! }
+//!
+//! impl Config for SampleConfig {
+//!     fn load() -> Result<Self, ConfigError> {
+//!         Ok(Self { debug: true })
+//!     }
+//!
+//!     fn validate(&self) -> Result<(), ConfigError> {
+//!         if self.debug {
+//!             Ok(())
+//!         } else {
+//!             Err(ConfigError::Validation {
+//!                 message: "debug must be enabled".into(),
+//!             })
+//!         }
+//!     }
+//! }
+//!
+//! # fn main() -> Result<(), ConfigError> {
+//! let cfg = SampleConfig::load()?;
+//! cfg.validate()?;
+//! # Ok(())
+//! # }
+//! ```
+
+use thiserror::Error;
+
+/// A trait implemented by all configuration types.
+///
+/// Types implementing `Config` are expected to provide a static `load`
+/// function that aggregates configuration from known sources as well as a
+/// `validate` method that ensures the resulting configuration is usable.
+/// Implementations should strive to keep both operations side-effect free
+/// and deterministic.
+pub trait Config: Sized {
+    /// Load the configuration from the configured sources.
+    ///
+    /// Implementations typically gather configuration from multiple
+    /// providers before merging the results using a [`MergeStrategy`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError`] when no valid configuration can be
+    /// constructed.
+    fn load() -> Result<Self, ConfigError>;
+
+    /// Validate the configuration according to custom invariants.
+    ///
+    /// Implementations should ensure that all required invariants are
+    /// checked. The method is expected to be idempotent and not mutate the
+    /// configuration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ConfigError::Validation`] when validation fails.
+    fn validate(&self) -> Result<(), ConfigError>;
+}
+
+/// Strategies available when merging multiple configuration sources.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeStrategy {
+    /// Later sources override earlier values during merging.
+    Override,
+    /// Earlier values are preserved unless later sources produce new keys.
+    Preserve,
+}
+
+/// Error variants produced when loading or validating configuration data.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// Errors that occur during the loading phase.
+    #[error("failed to load configuration: {message}")]
+    Load {
+        /// Description of the loading failure.
+        message: String,
+    },
+    /// Errors produced by merging multiple configuration sources.
+    #[error("failed to merge configuration: {message}")]
+    Merge {
+        /// Description of the merging failure.
+        message: String,
+    },
+    /// Errors emitted by validation logic.
+    #[error("configuration validation failed: {message}")]
+    Validation {
+        /// Description of the validation failure.
+        message: String,
+    },
+}

--- a/cnfg-derive/Cargo.toml
+++ b/cnfg-derive/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cnfg-derive"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+proc-macro = true

--- a/cnfg-derive/src/lib.rs
+++ b/cnfg-derive/src/lib.rs
@@ -1,0 +1,7 @@
+#![deny(missing_docs, warnings)]
+
+//! Procedural macros for deriving `cnfg` configuration implementations.
+//!
+//! The derive crate is currently a placeholder. Future iterations will expose
+//! the `#[derive(Config)]` macro that generates trait implementations based on
+//! annotations.

--- a/cnfg-examples/Cargo.toml
+++ b/cnfg-examples/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "cnfg-examples"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dev-dependencies]
+cnfg-core = { path = "../cnfg-core" }

--- a/cnfg-examples/src/lib.rs
+++ b/cnfg-examples/src/lib.rs
@@ -1,0 +1,7 @@
+#![deny(missing_docs, warnings)]
+
+//! Example applications and integration tests for the `cnfg` framework.
+//!
+//! This crate hosts sample configuration models that exercise the public
+//! API. It intentionally has no library exports; the examples live in the
+//! `tests/` directory to validate the workspace end-to-end.

--- a/cnfg-examples/tests/manual_impl.rs
+++ b/cnfg-examples/tests/manual_impl.rs
@@ -1,0 +1,34 @@
+use cnfg_core::{Config, ConfigError, MergeStrategy};
+
+#[derive(Debug)]
+struct DummyConfig {
+    debug: bool,
+    strategy: MergeStrategy,
+}
+
+impl Config for DummyConfig {
+    fn load() -> Result<Self, ConfigError> {
+        Ok(Self {
+            debug: true,
+            strategy: MergeStrategy::Override,
+        })
+    }
+
+    fn validate(&self) -> Result<(), ConfigError> {
+        if self.debug {
+            Ok(())
+        } else {
+            Err(ConfigError::Validation {
+                message: "debug must be enabled".into(),
+            })
+        }
+    }
+}
+
+#[test]
+fn manual_config_impl_succeeds() -> Result<(), ConfigError> {
+    let config = DummyConfig::load()?;
+    config.validate()?;
+    assert!(matches!(config.strategy, MergeStrategy::Override));
+    Ok(())
+}

--- a/cnfg-sources/Cargo.toml
+++ b/cnfg-sources/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "cnfg-sources"
+version = "0.1.0"
+edition = "2021"
+publish = false

--- a/cnfg-sources/src/lib.rs
+++ b/cnfg-sources/src/lib.rs
@@ -1,0 +1,7 @@
+#![deny(missing_docs, warnings)]
+
+//! Source adapters for loading configuration data.
+//!
+//! The crate currently acts as a placeholder and will eventually host
+//! adapters for reading configuration from files, environment variables, and
+//! command-line arguments.

--- a/cnfg-validate/Cargo.toml
+++ b/cnfg-validate/Cargo.toml
@@ -1,0 +1,5 @@
+[package]
+name = "cnfg-validate"
+version = "0.1.0"
+edition = "2021"
+publish = false

--- a/cnfg-validate/src/lib.rs
+++ b/cnfg-validate/src/lib.rs
@@ -1,0 +1,6 @@
+#![deny(missing_docs, warnings)]
+
+//! Validation helpers for `cnfg` configuration models.
+//!
+//! The validation crate is currently empty but will grow to include reusable
+//! validators for common configuration patterns.

--- a/cnfg/Cargo.toml
+++ b/cnfg/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "cnfg"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+cnfg-core = { path = "../cnfg-core" }
+cnfg-derive = { path = "../cnfg-derive" }
+cnfg-sources = { path = "../cnfg-sources" }
+cnfg-validate = { path = "../cnfg-validate" }

--- a/cnfg/src/lib.rs
+++ b/cnfg/src/lib.rs
@@ -1,0 +1,17 @@
+#![deny(missing_docs, warnings)]
+
+//! User-facing entry point for the `cnfg` configuration framework.
+//!
+//! The meta-crate re-exports all commonly used traits, error types, macros,
+//! and utilities from the individual `cnfg-*` crates. Downstream users can
+//! depend on this crate alone and access the framework with
+//! `use cnfg::Config;` without worrying about the internal crate layout.
+
+/// Re-export of the core configuration trait and supporting types.
+pub use cnfg_core::{Config, ConfigError, MergeStrategy};
+/// Placeholder re-export of the derive macros crate.
+pub use cnfg_derive as derive;
+/// Placeholder re-export of the configuration sources crate.
+pub use cnfg_sources as sources;
+/// Placeholder re-export of the validation utilities crate.
+pub use cnfg_validate as validate;


### PR DESCRIPTION
## Summary
- scaffold the cnfg workspace with core, derive, sources, validate, examples, and meta crates
- implement the cnfg-core trait, merge strategy, and error enum with documentation
- add the cnfg meta crate re-exports and an integration test exercising a manual Config implementation

## Testing
- cargo test *(fails: unable to download crates.io index due to 403 CONNECT tunnel response)*

------
https://chatgpt.com/codex/tasks/task_e_68cdff179fa08326baa60a2776b09f28